### PR TITLE
Fixed `mUserInitiatedSignIn` not being reset when complete

### DIFF
--- a/BaseGameUtils/src/com/google/example/games/basegameutils/GameHelper.java
+++ b/BaseGameUtils/src/com/google/example/games/basegameutils/GameHelper.java
@@ -619,6 +619,7 @@ public class GameHelper implements GooglePlayServicesClient.ConnectionCallbacks,
         mSignedIn = true;
         mSignInError = false;
         mAutoSignIn = true;
+        mUserInitiatedSignIn = false;
         dismissDialog();
         if (mListener != null) {
             mListener.onSignInSucceeded();


### PR DESCRIPTION
`mUserInitiatedSignIn` was not being reset to `false` after the sign in was complete. This was causing the sign in flow to start if a user signed out in a child Activity and was returning to its parent Activity.
