### PR TITLE
Only enable debug logging when enabled flag is set

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/BaseGameActivity.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/BaseGameActivity.java
@@ -156,7 +156,7 @@ public abstract class BaseGameActivity extends FragmentActivity implements
     }
 
     protected void enableDebugLog(boolean enabled, String tag) {
-        mDebugLog = true;
+        mDebugLog = enabled;
         mDebugTag = tag;
         if (mHelper != null) {
             mHelper.enableDebugLog(enabled, tag);


### PR DESCRIPTION
Previously mDebugLog was always set to true when calling enableDebugLog, no matter what value was passed in for enabled. This would cause onCreate to enable debug logging even if the last call to enableDebugLog had enabled=false.
