### PR TITLE
Added checking whether mActivity is null.

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -749,7 +749,9 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
                 // launch appropriate UI flow (which might, for example, be the
                 // sign-in flow)
                 mExpectingResolution = true;
-                mConnectionResult.startResolutionForResult(mActivity, RC_RESOLVE);
+                if (mActivity != null) {
+                    mConnectionResult.startResolutionForResult(mActivity, RC_RESOLVE);
+                }
             } catch (SendIntentException e) {
                 // Try connecting again
                 debugLog("SendIntentException, so connecting again.");


### PR DESCRIPTION
mActivity is cleared after `onStop` is invoked. Because
`resolveConnectResult` can be invoked after `onStop` and
uses mActivity, null pointer exception may occur. So we
have to check that mActivity is not null.
