### PR TITLE
Fix NullPointerException when clicking 'Leave'

### DIFF
--- a/eclipse_compat/SkeletonTbmp/src/com/google/example/tbmpskeleton/SkeletonActivity.java
+++ b/eclipse_compat/SkeletonTbmp/src/com/google/example/tbmpskeleton/SkeletonActivity.java
@@ -593,7 +593,7 @@ public class SkeletonActivity extends BaseGameActivity implements OnInvitationRe
         if (!checkStatusCode(match, result.getStatus().getStatusCode())) {
             return;
         }
-        isDoingTurn = (match.getTurnStatus() == TurnBasedMatch.MATCH_TURN_STATUS_MY_TURN);
+        isDoingTurn = false;
         showWarning("Left", "You've left this match.");
     }
 


### PR DESCRIPTION
`match.getTurnStatus()` returns null when clicking 'Leave' (in two player game at least, haven't tested with more). As we are leaving the game, `isDoingTurn` can just be set to `false`.
