### PR TITLE
Re-apply missing null check from Bruno Oliveira

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -843,6 +843,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             debugLog("We're already expecting the result of a previous resolution.");
             return;
         }
+        if (mActivity == null) {
+            Log.e(TAG, "Ignoring attempt to resolve connection result without an active Activity.");
+            return;
+        }
 
         debugLog("resolveConnectionResult: trying to resolve result: "
                 + mConnectionResult);


### PR DESCRIPTION
Reapplies the fix from commit e7b3758, which was mistakenly removed in 81ff43c. Fixes #60.
