### PR TITLE
Fixed NPE in GameHelper.onConnectionFailed. #65

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -849,6 +849,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
         if (mConnectionResult.hasResolution()) {
             // This problem can be fixed. So let's try to fix it.
             debugLog("Result has resolution. Starting it.");
+            if (mActivity == null) {
+                logError("*** resolveConnectionResult failed: no current Activity!");
+                return;
+            }
             try {
                 // launch appropriate UI flow (which might, for example, be the
                 // sign-in flow)
@@ -858,6 +862,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             } catch (SendIntentException e) {
                 // Try connecting again
                 debugLog("SendIntentException, so connecting again.");
+                connect();
+            } catch (NullPointerException e) {
+                // Try connecting again
+                debugLog("NullPointerExcception, so connecting again.");
                 connect();
             }
         } else {

--- a/eclipse_compat/libraries/BaseGameUtils/src/com/google/example/games/basegameutils/GameHelper.java
+++ b/eclipse_compat/libraries/BaseGameUtils/src/com/google/example/games/basegameutils/GameHelper.java
@@ -849,6 +849,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
         if (mConnectionResult.hasResolution()) {
             // This problem can be fixed. So let's try to fix it.
             debugLog("Result has resolution. Starting it.");
+            if (mActivity == null) {
+                logError("*** resolveConnectionResult failed: no current Activity!");
+                return;
+            }
             try {
                 // launch appropriate UI flow (which might, for example, be the
                 // sign-in flow)
@@ -858,6 +862,10 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             } catch (SendIntentException e) {
                 // Try connecting again
                 debugLog("SendIntentException, so connecting again.");
+                connect();
+            } catch (NullPointerException e) {
+                // Try connecting again
+                debugLog("NullPointerExcception, so connecting again.");
                 connect();
             }
         } else {


### PR DESCRIPTION
Null pointer exception occured in `GameHelper.onConeectionFailed`.

Fixed GameHelpers of BasicSamples and elipse_compat.

I think mActivity is the cause of NPE. But I could not say with
confidence. So I added a try-catch too.

I didn't modified EndlessTunnel's GameHelper. It uses the different
verion of GameHelper.
