### PR TITLE
GameHelper bugfix

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -124,7 +124,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
     public final static int CLIENT_GAMES = 0x01;
     public final static int CLIENT_PLUS = 0x02;
     public final static int CLIENT_APPSTATE = 0x04;
-    public final static int CLIENT_SNAPSHOT = 0x05;
+    public final static int CLIENT_SNAPSHOT = 0x08;
     public final static int CLIENT_ALL = CLIENT_GAMES | CLIENT_PLUS
             | CLIENT_APPSTATE | CLIENT_SNAPSHOT;
 


### PR DESCRIPTION
By having CLIENT_SNAPSHOT set to 5, it will get enabled if CLIENT_GAMES (1) and CLIENT_APPSTATE (4) are both enabled as well. It was meant to be a binary flag I think, so changing it to 8 fixes this.
