### PR TITLE
Change google play services version to 5.0.89

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/build.gradle
+++ b/BasicSamples/libraries/BaseGameUtils/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 dependencies {
     compile 'com.android.support:appcompat-v7:20.0.+'
     compile 'com.android.support:support-v4:20.0.+'
-    compile 'com.google.android.gms:play-services:+'
+    compile 'com.google.android.gms:play-services:5.0.89'
 }
 
 android {


### PR DESCRIPTION
By having     compile 'com.google.android.gms:play-services:+ gradle downloads the latest version which is 5.2 and has not released yet 
So i suggest we use 5.0.89 in order to avoid confusion and errors.

Awesome work.
Keep on coding.
