### PR TITLE
Prevent NPE when resolving network connection

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -856,7 +856,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
 
         debugLog("resolveConnectionResult: trying to resolve result: "
                 + mConnectionResult);
-        if (mConnectionResult.hasResolution()) {
+        if (mConnectionResult.hasResolution() && mActivity != null) {
             // This problem can be fixed. So let's try to fix it.
             debugLog("Result has resolution. Starting it.");
             try {


### PR DESCRIPTION
If the activity reference is null when attempting to resolve the network connection, the following method will cause a NPE. 

```
mConnectionResult.startResolutionForResult(mActivity, RC_RESOLVE);
```

We can safely fail the resolution attempt and give up.
