### PR TITLE
Fixing UTF8 bug

### DIFF
--- a/BasicSamples/SkeletonTbmp/src/main/java/com/google/example/tbmpskeleton/SkeletonTurn.java
+++ b/BasicSamples/SkeletonTbmp/src/main/java/com/google/example/tbmpskeleton/SkeletonTurn.java
@@ -57,7 +57,7 @@ public class SkeletonTurn {
 
         Log.d(TAG, "==== PERSISTING\n" + st);
 
-        return st.getBytes(Charset.forName("UTF-16"));
+        return st.getBytes(Charset.forName("UTF-8"));
     }
 
     // Creates a new instance of SkeletonTurn.
@@ -70,7 +70,7 @@ public class SkeletonTurn {
 
         String st = null;
         try {
-            st = new String(byteArray, "UTF-16");
+            st = new String(byteArray, "UTF-8");
         } catch (UnsupportedEncodingException e1) {
             e1.printStackTrace();
             return null;


### PR DESCRIPTION
Same thing as in ios-basic-samples.  The decision to use UTF-16 does not seem to be helpful at all.  Using UTF-8 for data makes it compatible with web (due to base64 translation).
