### PR TITLE
fix NPE in GameHelper.resolveConnectionResult

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -854,6 +854,11 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             return;
         }
 
+        if (mActivity == null) {
+            debugLog("No need to resolve issue, activity does not exist anymore");
+            return;
+        }
+
         debugLog("resolveConnectionResult: trying to resolve result: "
                 + mConnectionResult);
         if (mConnectionResult.hasResolution()) {


### PR DESCRIPTION
I've got several reports with such stacktrace from my users:

```
java.lang.NullPointerException
       at com.google.android.gms.common.ConnectionResult.startResolutionForResult()
       at com.google.example.games.basegameutils.GameHelper.resolveConnectionResult(GameHelper.java:866)
       at com.google.example.games.basegameutils.GameHelper.onConnectionFailed(GameHelper.java:842)
       at com.google.android.gms.common.internal.e.b()
       at com.google.android.gms.common.api.b.gn()
       at com.google.android.gms.common.api.b.d()
       at com.google.android.gms.common.api.b$4.onConnectionFailed()
       at com.google.android.gms.common.internal.e.b()
       at com.google.android.gms.common.internal.d$h.b()
       at com.google.android.gms.common.internal.d$h.g()
       at com.google.android.gms.common.internal.d$b.gU()
       at com.google.android.gms.common.internal.d$a.handleMessage()
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:157)
       at android.app.ActivityThread.main(ActivityThread.java:5872)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:515)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:858)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:674)
       at dalvik.system.NativeStart.main(NativeStart.java)
```

This commit should fix the issue.
