### PR TITLE
Update TQ to match config tool achievement style

### DIFF
--- a/BasicSamples/TrivialQuest/src/main/java/com/google/example/games/tq/MainActivity.java
+++ b/BasicSamples/TrivialQuest/src/main/java/com/google/example/games/tq/MainActivity.java
@@ -115,7 +115,7 @@ public class MainActivity extends Activity
         // NOTE: this check is here only because this is a sample! Don't include this
         // check in your actual production app.
         if (!BaseGameUtils.verifySampleSetup(this, R.string.app_id,
-            R.string.trivial_victory_achievement_id)) {
+            R.string.achievement_trivial_victory)) {
           Log.w(TAG, "*** Warning: setup problems detected. Sign in may not work!");
         }
 
@@ -139,7 +139,7 @@ public class MainActivity extends Activity
         if (mGoogleApiClient.isConnected()) {
           // unlock the "Trivial Victory" achievement.
           Games.Achievements.unlock(mGoogleApiClient,
-              getString(R.string.trivial_victory_achievement_id));
+              getString(R.string.achievement_trivial_victory));
         }
         break;
     }

--- a/BasicSamples/TrivialQuest/src/main/res/values/ids.xml
+++ b/BasicSamples/TrivialQuest/src/main/res/values/ids.xml
@@ -20,5 +20,5 @@
     <string name="app_id">ReplaceMe</string>
 
     <!-- Replace by your "Trivial Victory" achievement ID -->
-    <string name="trivial_victory_achievement_id">ReplaceMe</string>
+    <string name="achievement_trivial_victory">ReplaceMe</string>
 </resources>


### PR DESCRIPTION
The config tool creates achievements with the name `achievement_some_name`.  All samples that want to use the tool should update to this style.
@claywilkinson please merge.