### PR TITLE
Reconnect when reconnect is required

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/GameHelper.java
@@ -574,7 +574,7 @@ public class GameHelper implements GoogleApiClient.ConnectionCallbacks,
             connect();
         } else if (responseCode == GamesActivityResultCodes.RESULT_RECONNECT_REQUIRED) {
             debugLog("onAR: Resolution was RECONNECT_REQUIRED, so reconnecting.");
-            connect();
+            reconnectClient();
         } else if (responseCode == Activity.RESULT_CANCELED) {
             // User cancelled.
             debugLog("onAR: Got a cancellation result, so disconnecting.");


### PR DESCRIPTION
After signing out from the Google Play Game settings within the app, the GameHelper's client still believes it is connected.

By calling reconnectClient instead of connect, the status of the client will be updated.

Should solve issues #121 and #149. 