### PR TITLE
bug fix of room initialization and invitation popup from crashing app

### DIFF
--- a/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
+++ b/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
@@ -496,6 +496,9 @@ public class MainActivity extends Activity
         //get participants and my ID:
         mParticipants = room.getParticipants();
         mMyId = room.getParticipantId(Games.Players.getCurrentPlayerId(mGoogleApiClient));
+        
+         // save room ID so we can leave cleanly before the game starts.
+        mRoomId = room.getRoomId();
 
         // print out the list of participants (for debug purposes)
         Log.d(TAG, "Room ID: " + mRoomId);
@@ -535,8 +538,7 @@ public class MainActivity extends Activity
             return;
         }
 
-        // save room ID so we can leave cleanly before the game starts.
-        mRoomId = room.getRoomId();
+       
 
         // show the waiting room UI
         showWaitingRoom(room);

--- a/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
+++ b/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
@@ -426,10 +426,12 @@ public class MainActivity extends Activity
 
     @Override
     public void onInvitationRemoved(String invitationId) {
-        if (mIncomingInvitationId.equals(invitationId)) {
+        if( mIncomingInvitationId!=null)
+      {  if (mIncomingInvitationId.equals(invitationId)) {
             mIncomingInvitationId = null;
             switchToScreen(mCurScreen); // This will hide the invitation popup
         }
+      }
     }
 
     /*

--- a/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
+++ b/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
@@ -426,12 +426,12 @@ public class MainActivity extends Activity
 
     @Override
     public void onInvitationRemoved(String invitationId) {
-        if( mIncomingInvitationId!=null)
-      {  if (mIncomingInvitationId.equals(invitationId)) {
+       
+        if (mIncomingInvitationId.equals(invitationId)&&mIncomingInvitationId!=null) {
             mIncomingInvitationId = null;
             switchToScreen(mCurScreen); // This will hide the invitation popup
         }
-      }
+      
     }
 
     /*
@@ -499,8 +499,9 @@ public class MainActivity extends Activity
         mParticipants = room.getParticipants();
         mMyId = room.getParticipantId(Games.Players.getCurrentPlayerId(mGoogleApiClient));
         
-         // save room ID so we can leave cleanly before the game starts.
-        mRoomId = room.getRoomId();
+         // save room ID if its not initialized in onRoomCreated() so we can leave cleanly before the game starts.
+         if(mRoomId==null)
+          mRoomId = room.getRoomId();
 
         // print out the list of participants (for debug purposes)
         Log.d(TAG, "Room ID: " + mRoomId);
@@ -540,7 +541,8 @@ public class MainActivity extends Activity
             return;
         }
 
-       
+       // save room ID so we can leave cleanly before the game starts.
+        mRoomId = room.getRoomId();
 
         // show the waiting room UI
         showWaitingRoom(room);


### PR DESCRIPTION
#in ButtonClicker

#commit 1: roomId need to initialize in onConnectedToRoom(Room room) as this callback will surely call in all players app rather than in onRoomCreated(int statusCode, Room room) which guarantees to call only in the player who initiate play invitation or room creation for other players.

#commit 2: To avoid crash of application from ignored invitation request like closing application just when invitation pop up (edge case appeared in some use case)
