### PR TITLE
Add defaultConfig to BaseGameUtils gradle file

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/build.gradle
+++ b/BasicSamples/libraries/BaseGameUtils/build.gradle
@@ -19,7 +19,7 @@ dependencies {
         ext.support_library_version = '20.0.+'
     }
     if (!project.hasProperty('gms_library_version')) {
-        ext.gms_library_version = '8.1.0'
+        ext.gms_library_version = '8.4.0'
     }
 
     compile "com.android.support:appcompat-v7:${appcompat_library_version}"
@@ -33,16 +33,19 @@ android {
     if (!project.hasProperty('android_compile_version')) {
         ext.android_compile_version = 23
     }
+    if (!project.hasProperty('android_min_version')) {
+        ext.android_min_version = 15
+    }
     if (!project.hasProperty('android_version')) {
-        ext.android_version = '23'
+        ext.build_tools_version = "23.0.2"
     }
 
     compileSdkVersion android_compile_version
-    buildToolsVersion android_version
+    buildToolsVersion build_tools_version
 
     defaultConfig {
-        minSdkVersion 15
-        targetSdkVersion 23
+        minSdkVersion android_min_version
+        targetSdkVersion android_compile_version
     }
 }
 

--- a/BasicSamples/libraries/BaseGameUtils/build.gradle
+++ b/BasicSamples/libraries/BaseGameUtils/build.gradle
@@ -39,5 +39,10 @@ android {
 
     compileSdkVersion android_compile_version
     buildToolsVersion android_version
+
+    defaultConfig {
+        minSdkVersion 15
+        targetSdkVersion 23
+    }
 }
 


### PR DESCRIPTION
This is a fix for building projects including BaseGameUtils as a gradle module, using android gradle build tools 2.2.0

Fixes the following error
```
Caused by: java.lang.RuntimeException: Manifest merger failed : uses-sdk:minSdkVersion 1 cannot be smaller than version 7 declared in library [com.android.support:appcompat-v7:20.0.0] /Users/me/folders/android-basic-samples/BasicSamples/libraries/BaseGameUtils/build/intermediates/exploded-aar/com.android.support/appcompat-v7/20.0.0/AndroidManifest.xml
```