### PR TITLE
Fixed stuck on "please wait" in ButtonClicker app

### DIFF
--- a/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
+++ b/BasicSamples/ButtonClicker/src/main/java/com/google/example/games/bc/MainActivity.java
@@ -346,11 +346,10 @@ public class MainActivity extends Activity
         // stop trying to keep the screen on
         stopKeepingScreenOn();
 
-        if (mGoogleApiClient == null || !mGoogleApiClient.isConnected()){
-          switchToScreen(R.id.screen_sign_in);
-        }
-        else {
-          switchToScreen(R.id.screen_wait);
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
+            switchToMainScreen();
+        } else {
+            switchToScreen(R.id.screen_sign_in);
         }
         super.onStop();
       }
@@ -361,13 +360,15 @@ public class MainActivity extends Activity
     // this flow simply succeeds and is imperceptible).
     @Override
     public void onStart() {
-        switchToScreen(R.id.screen_wait);
-        if (mGoogleApiClient != null && mGoogleApiClient.isConnected()) {
-          Log.w(TAG,
-              "GameHelper: client was already connected on onStart()");
+        if (mGoogleApiClient == null) {
+            switchToScreen(R.id.screen_sign_in);
+        } else if (!mGoogleApiClient.isConnected()) {
+            Log.d(TAG,"Connecting client.");
+            switchToScreen(R.id.screen_wait);
+            mGoogleApiClient.connect();
         } else {
-          Log.d(TAG,"Connecting client.");
-          mGoogleApiClient.connect();
+            Log.w(TAG,
+              "GameHelper: client was already connected on onStart()");
         }
         super.onStart();
     }


### PR DESCRIPTION
ButtonClicker app would get stuck on the "please wait" screen whenever onStop was called. This happened because switchToScreen(R.id.screen_wait) would be called from both onStop and onStart if the GoogleApiClient was not null and connected, with no subsequent calls made to show a different screen.