### PR TITLE
Some small fixes for the "Accessing APIs" tutorial

### DIFF
--- a/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/BaseGameUtils.java
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/java/com/google/example/games/basegameutils/BaseGameUtils.java
@@ -38,7 +38,7 @@ public class BaseGameUtils {
      */
     public static boolean resolveConnectionFailure(Activity activity,
                                                    GoogleApiClient client, ConnectionResult result, int requestCode,
-                                                   String fallbackErrorMessage) {
+                                                   int fallbackErrorMessage) {
 
         if (result.hasResolution()) {
             try {
@@ -59,7 +59,7 @@ public class BaseGameUtils {
                 dialog.show();
             } else {
                 // no built-in dialog: show the fallback error message
-                showAlert(activity, fallbackErrorMessage);
+                showAlert(activity, activity.getString(fallbackErrorMessage));
             }
             return false;
         }

--- a/BasicSamples/libraries/BaseGameUtils/src/main/res/values/strings.xml
+++ b/BasicSamples/libraries/BaseGameUtils/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="sign_in_other_error">There was an issue with sign-in, please try again later.</string>
     <string name="sign_in_failed">Failed to sign in. Please check your network connection and try again.</string>
     <string name="app_misconfigured">The application is incorrectly configured. Check that the package name and signing certificate match the client ID created in Developer Console. Also, if the application is not yet published, check that the account you are trying to sign in with is listed as a tester account. See logs for more information.</string>
     <string name="license_failed">License check failed.</string>


### PR DESCRIPTION
I'm following the tutorial at https://developers.google.com/games/services/android/init, and these are a few little things that tripped me up. For instance, I had no idea why `BaseGameUtils.resolveConnectionFailure` was complaining about me passing an `int` instead of a `String`, but that was just a bug in the original `BaseGameUtils` code. (`R.string.sign_in_other_error` is actually an `int`, and you need to call `getString()` on the resource id.)

I also added the missing `sign_in_other_error` string from the tutorial, because I'm not sure why that was excluded.